### PR TITLE
Add environment variables for configuring Jolocom

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,11 @@ WORKDIR /app
 COPY package.json package-lock.json ./
 
 # Install all Packages
-RUN npm install
+RUN npm ci
+
+# Patch jolocom lib to allow manual transfer of funds to organization
+COPY ./helper.js.patch .
+RUN patch -p1 < ./helper.js.patch
 
 # Copy all other source code to work directory
 COPY . ./
@@ -21,4 +25,4 @@ COPY . ./
 EXPOSE 3000
 
 # need to build at runtime because config.ts might be replaced/mounted
-CMD [ "npm", "run", "start:dev" ]
+CMD [ "npm", "run", "start:debug" ]

--- a/README.md
+++ b/README.md
@@ -54,6 +54,85 @@ $ npm run test:e2e
 # test coverage
 $ npm run test:cov
 ```
+## Jolocom
+
+The Jolocom connector will not work out-of-the-box. For more information, keep
+reading.
+
+The default Jolocom implementation is built on top of the Ethereum Blockchain.
+The blockchain is used as the "Verifiable Data Registry". This registry allows
+DIDs to be translated into DID documents.
+
+For testing purposes, the development version of Jolocom includes a "Ethereum
+Smart Contract" on the Rinkeby Testnet. Since The Merge however, the Rinkeby
+Testnet has been deprecated and removed.
+
+To use the Jolocom connector, you will therefore need to deploy your own Smart
+Contract to act as the Verifiable Data Registry. This section describes one way
+of doing this.
+
+1. Setup a Wallet (for yourself, not an organisation)
+   1. Download an Ethereum Wallet (MetaMask recommended, which works in-browser and is widely supported). Make sure to use and write down your seed phrase.
+   2. Add the Sepolia Testnet to your Wallet by browsing `https://sepolia.dev/` and
+      pressing "Add to MetaMask"
+2. Connect to a Blockchain Node (Provider). You can (in theory) run your own node, but its quickest and easiest to use a Blockhain Node Provider such as Alchemy:
+   1. Create an account on `alchemy.com`
+   2. Create an App on `dashboard.alchemy.com`. Note down the API Key.
+3. Deploy the Smart Contract
+   1. Install Node v14
+      - The current project only works (as far as I can tell) with Node v14
+      - Installing an older Node version is most easily achieved using [Node Version Manager](https://github.com/nvm-sh/nvm)
+      - i.e. using the command `nvm install lts/fermium`
+   2. Clone the repository
+      - `git clone jolocom/jolo-did-method`
+   3. Navigate to the contract package
+      - `cd packages/registry-contract`
+   4. Add the Sepolia Testnet to `truffle.config.js`:
+      ```javascript
+      ...
+      const HDWalletProvider = require("@truffle/hdwallet-provider");
+
+      module.exports = {
+          networks: {
+              sepolia: {
+                  provider: () => {
+                      return new HDWalletProvider(
+                          "<YOUR WALLET SEED PHRASE / MNEMONIC",
+                          "https://eth-sepolia.g.alchemy.com/v2/<YOUR ALCHEMY API KEY>"
+                      );
+                  },
+                  network_id: 11155111,
+              },
+              ...
+          },
+          ...
+      };
+      ```
+   5. Install dependencies
+      - `npm ci && npm install @truffle/hdwallet-provider && npm install --global truffle`
+   6. Deploy the contract on the Sepolia Testnet
+      - `trouble deploy --network sepolia`
+      - Make sure to write down the address at which your contract is deployed
+4. Configure the backend to use your new smart contract
+    - Set the following environment variables
+        - `JOLOCOM_PROVDER_URL` with `https://eth-sepolia.g.alchemy.com/v2/<YOUR ALCHEMY API KEY>` (if you opted to use Alchemy)
+        - `JOLOCOM_CONTRACT_ADDRESS` with the address at which your contract is deployed
+    - If you are using `eassi-deployment`, set these in the `.env` file
+5. Fix the leaky faucet
+    - Unfortunately, the default faucet used by the Jolocom library internally
+      is in need of a plumber (it was a Rinkeby faucet which is offline). The
+      backend repository includes a `helper.js.patch` file which alters the
+      `jolocom-lib` to wait for 60 seconds after creating a Wallet (generating
+      its cryptographic keypair) before anchoring it on the blockchain
+      (registering it to the registy smart contract, which requires
+      ethereum/fuel). In these 60 seconds, you have the time to copy the Wallet
+      address (see the console output) and send funds to it, so that the Wallet
+      anchoring process can succeed.
+    - The patch file can be applied as follows (assuming you currently reside in
+      the root of this repository):
+        - `patch -p1 < ./helper.js.patch`
+        - Or perform this directly in the docker container (easier):
+            `docker compose -f ./docker-compose.dev.yml run backend sh -c "path -p1 < ./helper.js.patch"`
 
 ## License
 

--- a/helper.js.patch
+++ b/helper.js.patch
@@ -1,0 +1,35 @@
+--- ./node_modules/jolocom-lib/js/utils/helper.js	2023-03-15 16:23:35.550819991 +0100
++++ ./helper.js	2023-03-15 16:26:41.927582984 +0100
+@@ -17,7 +17,25 @@
+     return keyId.substring(0, keyId.indexOf('#'));
+ }
+ exports.keyIdToDid = keyIdToDid;
++const countdown = async (countdown) => {
++    console.log('Waiting for funds (60 seconds)...');
++    return new Promise((resolve) => {
++        const interval = setInterval(() => {
++            countdown -= 1;
++            if (countdown == 0) {
++                console.log('Continuing...');
++                resolve();
++                clearInterval(interval);
++            }
++        }, 1000);
++    });
++};
+ function fuelKeyWithEther(publicKey) {
++    console.log(
++        'Please manually fund the following address: ',
++        exports.publicKeyToAddress(publicKey),
++    );
++    return countdown(60);
+     return node_fetch_1.default('https://faucet.jolocom.com/request/', {
+         method: 'POST',
+         body: JSON.stringify({ address: exports.publicKeyToAddress(publicKey) }),
+@@ -45,4 +63,4 @@
+         encryptionKeyId: encKeyRef,
+     };
+ };
+-//# sourceMappingURL=helper.js.map
+\ No newline at end of file
++//# sourceMappingURL=helper.js.map

--- a/src/connectors/jolocom/jolocom.module.ts
+++ b/src/connectors/jolocom/jolocom.module.ts
@@ -13,7 +13,12 @@ import { DidMethodKeeper } from '@jolocom/sdk/js/didMethodKeeper';
 import { JoloDidMethod } from 'jolocom-lib/js/didMethods/jolo';
 
 const PROVIDER_URL =
+  process.env.JOLOCOM_PROVIDER_URL ||
   'https://rinkeby.infura.io/v3/683ec89a2ede42f8a29842b5ebbef450';
+const CONTRACT_ADDRESS =
+  process.env.JOLOCOM_CONTRACT_ADDRESS ||
+  // Default contract address (see github jolocom/jolo-did-method, 'packages/jolo-did-registrar/ts/index.ts')
+  '0xd4351c3f383d79ba378ed1875275b1e7b960f120';
 
 const jolocomSDKFactory = {
   provide: JolocomSDK,
@@ -22,8 +27,8 @@ const jolocomSDKFactory = {
       storage: new JolocomTypeormStorage(connection),
     });
 
-    // Use custom rinkeby endpoint
-    const jolo = new JoloDidMethod(PROVIDER_URL);
+    // Use custom testnet endpoint
+    const jolo = new JoloDidMethod(PROVIDER_URL, CONTRACT_ADDRESS);
     const mk = new DidMethodKeeper(jolo);
     mk.register('jun', sdk.didMethods.get('jun'));
     sdk.didMethods = mk;

--- a/src/organizations/organizations.service.ts
+++ b/src/organizations/organizations.service.ts
@@ -39,11 +39,11 @@ export class OrganizationsService {
     organization.name = name;
     organization.sharedSecret = Organization.randomSecret();
     await this.organizationsRepository.save(organization);
+    this.logger.debug(`Created organization: ${JSON.stringify(organization)}`);
 
     // TODO: Move to queue if needed.
     await this.connectorsService.registerOrganization(organization);
 
-    this.logger.debug(`Created organization (id: ${organization.id})`);
     // return organization;
     return {
       "id": organization.id,


### PR DESCRIPTION
Closes #24 

This PR adds two environment variables JOLOCOM_PROVIDER_URL and JOLOCOM_CONTRACT_ADDRESS to allow the developer to configure which Ethereum Network and Registry Contract to use.

I added a section in the README explaining how to get the connector working again. Step 5 is a rather fragile duct tape fix around the unusable Jolocom faucet. A proper fix should be implemented by Jolocom in their library.