### PR TITLE
Disable Jolocom wallet creation on organization registration

### DIFF
--- a/src/connectors/jolocom/jolocom.service.ts
+++ b/src/connectors/jolocom/jolocom.service.ts
@@ -59,7 +59,7 @@ export class JolocomService implements ConnectorService {
   /* ConnectorService methods */
 
   async registerOrganization(organization: Organization) {
-    await this.createWalletForOrganization(organization);
+    // await this.createWalletForOrganization(organization);
     // await this.fuelWallet(wallet);
     // await this.registerWallet(wallet);
   }


### PR DESCRIPTION
@peterlangenkamp This is a hotfix to disable the jolocom wallet creation.

The jolocom wallet registration is currently broken, as the `jolocom-lib` relies on a smart contract on the Rinkeby Testnet, which no longer exists.